### PR TITLE
Forbidden ANSI Keyword Refactor

### DIFF
--- a/src/main/java/net/querybuilder4j/sql/builder/SqlBuilder.java
+++ b/src/main/java/net/querybuilder4j/sql/builder/SqlBuilder.java
@@ -75,7 +75,7 @@ public abstract class SqlBuilder {
 
         /*
         Interpolate the sub queries into the SelectStatement's criteria after validation so that SQL keywords like
-        "SELECT", "*", and "FROM" do not raise an exception when getting the results of a Common Table Expression.
+        "SELECT" and "*" do not raise an exception when getting the results of a Common Table Expression.
          */
         SqlPrimer.interpolateSubQueries(selectStatement);
 

--- a/src/main/java/net/querybuilder4j/sql/builder/SqlValidator.java
+++ b/src/main/java/net/querybuilder4j/sql/builder/SqlValidator.java
@@ -38,20 +38,9 @@ public class SqlValidator {
     // If any of these characters are contained in SelectStatement, then return false.
     private static final String[] forbiddenMarks = new String[] {";", "`", "\""};
 
-    // Ansi keywords per https://docs.snowflake.net/manuals/sql-reference/reserved-keywords.html.  I did not include 'TRUE' and
-    //   'FALSE' from the link's list because those are valid SelectStatement filters.
-    // If any of these strings are contained in SelectStatement, then return false.
-    // Did not include "AND", because this is a common word in filters.
-    private static final String[] ansiKeywords = new String[] {"ALL", "ALTER", "ANY", "AS", "ASC", "BETWEEN",
-            "BY", "CASE", "CAST", "CHECK", "CLUSTER", "COLUMN", "CONNECT", "CREATE", "CROSS", "CURRENT_DATE",
-            "CURRENT_ROLE", "CURRENT_USER", "CURRENT_TIME", "CURRENT_TIMESTAMP", "DELETE", "DESC", "DISTINCT",
-            "DROP", "ELSE", "EXCLUSIVE", "EXISTS", "FOR", "FROM", "FULL", "GRANT", "GROUP",
-            "HAVING", "IDENTIFIED", "ILIKE", "IMMEDIATE", "IN", "INCREMENT", "INNER", "INSERT", "INTERSECT",
-            "INTO", "IS", "JOIN", "LATERAL", "LEFT", "LIKE", "LOCK", "LONG", "MAXEXTENTS", "MINUS", "MODIFY",
-            "NATURAL", "NOT", "NULL", "OF", "ON", "OPTION", "OR", "REGEXP", "RENAME", "REVOKE", "RIGHT",
-            "RLIKE", "ROW", "ROWS", "SAMPLE", "SELECT", "SET", "SOME", "START", "TABLE", "TABLESAMPLE",
-            "THEN", "TO", "TRIGGER", "UNION", "UNIQUE", "UPDATE", "USING", "VALUES", "VIEW", "WHEN",
-            "WHENEVER", "WHERE", "WITH"
+    // Forbidden ANSI keywords that retrieve or change data.  These should not be present in the criterion filter values.
+    private static final String[] ansiKeywords = new String[] {
+            "UPDATE", "INSERT", "DROP", "DELETE", "SELECT"
     };
 
     public static void assertIsValid(SelectStatement selectStatement, DatabaseMetadataCacheDao databaseMetadataCacheDao) {


### PR DESCRIPTION
Relaxed ANSI keyword array memberes to only keywords that retrieve or change data.  The current list of forbidden ANSI keywords proved to be too strict.  For example, criterion filter values containing ` IN` as in `HENOS INDUSTRIES` were being flagged as unclean SQL.